### PR TITLE
🧪 Add tests for app.py endpoints

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,5 @@
 pytest
 pyyaml
+pytest-asyncio
+pytest-aiohttp
+pytest-mock

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,30 @@
+import pytest
+import pytest_asyncio
+from aiohttp import web
+from http import HTTPStatus
+from unittest.mock import AsyncMock
+
+from app import messages
+
+@pytest_asyncio.fixture
+async def cli(aiohttp_client):
+    app = web.Application()
+    app.router.add_post("/api/messages", messages)
+    return await aiohttp_client(app)
+
+@pytest.mark.asyncio
+async def test_messages_unsupported_media_type(cli):
+    """Test that a non-JSON request returns 415 UNSUPPORTED_MEDIA_TYPE"""
+    resp = await cli.post("/api/messages", data="not json", headers={"Content-Type": "text/plain"})
+    assert resp.status == HTTPStatus.UNSUPPORTED_MEDIA_TYPE
+
+@pytest.mark.asyncio
+async def test_messages_json_media_type(cli, mocker):
+    """Test that a valid JSON request is processed and returns expected status"""
+    mock_process = mocker.patch("app.ADAPTER.process", new_callable=AsyncMock)
+    mock_process.return_value = web.Response(status=HTTPStatus.OK)
+
+    resp = await cli.post("/api/messages", json={"type": "message", "text": "hello"}, headers={"Content-Type": "application/json"})
+
+    assert resp.status == HTTPStatus.OK
+    mock_process.assert_called_once()


### PR DESCRIPTION
🎯 **What:** The missing tests for the `messages` handler in `app.py` were addressed.
📊 **Coverage:** The scenarios now tested are:
- When a request is non-JSON, verifying it correctly returns a 415 UNSUPPORTED_MEDIA_TYPE.
- When a properly formatted JSON request is received, verifying it successfully processes through the BotBuilder adapter and returns a 200 OK status.
✨ **Result:** Test coverage significantly increased for the primary bot interaction endpoints, adding resilience for potential refactoring. `pytest-asyncio`, `pytest-aiohttp`, and `pytest-mock` were configured to support these new asynchronous suites.

---
*PR created automatically by Jules for task [10423495160044850627](https://jules.google.com/task/10423495160044850627) started by @Night-Hawkeye*