### PR TITLE
🔒 Fix Command Injection Vulnerability in Event Payload Creation

### DIFF
--- a/.github/workflows/test-1-create-a-branch.yml
+++ b/.github/workflows/test-1-create-a-branch.yml
@@ -23,28 +23,34 @@ jobs:
         run: curl https://raw.githubusercontent.com/nektos/act/master/install.sh | sudo bash
 
       - name: Create mock create event payload
+        env:
+          REPO_OWNER: ${{ github.repository_owner }}
+          EVENT_REPO_NAME: ${{ github.event.repository.name }}
+          REPO_FULL_NAME: ${{ github.repository }}
         run: |
-          cat << 'EOF' > event.json
-          {
-            "action": "opened",
-            "issue": {
-              "number": 1,
-              "title": "Introduction to GitHub",
-              "user": { "login": "${{ github.repository_owner }}" },
-              "state": "open"
-            },
-            "repository": {
-              "name": "${{ github.event.repository.name }}",
-              "full_name": "${{ github.repository }}",
-              "owner": {
-                "login": "${{ github.repository_owner }}"
+          jq -n \
+            --arg owner "$REPO_OWNER" \
+            --arg repo_name "$EVENT_REPO_NAME" \
+            --arg full_name "$REPO_FULL_NAME" \
+            '{
+              "action": "opened",
+              "issue": {
+                "number": 1,
+                "title": "Introduction to GitHub",
+                "user": { "login": $owner },
+                "state": "open"
+              },
+              "repository": {
+                "name": $repo_name,
+                "full_name": $full_name,
+                "owner": {
+                  "login": $owner
+                }
+              },
+              "sender": {
+                "login": $owner
               }
-            },
-            "sender": {
-              "login": "${{ github.repository_owner }}"
-            }
-          }
-          EOF
+            }' > event.json
 
       - name: Create Mock Issue
         id: create_issue


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a Command Injection vector within `.github/workflows/test-1-create-a-branch.yml`. Untrusted input, such as `${{ github.event.repository.name }}`, was being directly interpolated into a `run` script step that built a JSON payload string.

⚠️ **Risk:** If an attacker can control the value of the interpolated context variables (e.g. by creating a maliciously named repository or branch), they could break out of the string context and execute arbitrary code on the GitHub Actions runner. This could lead to a compromise of the build environment, exfiltration of secrets (like the `GITHUB_TOKEN`), or lateral movement.

🛡️ **Solution:** The fix maps these untrusted variables into the step's environment variables. It then leverages `jq` with the `--arg` flag to pass these variables securely into the JSON structure. This completely removes the risk of command injection, as the payload is parsed natively by `jq` rather than being evaluated by the bash shell during string interpolation.

---
*PR created automatically by Jules for task [4706791586310449266](https://jules.google.com/task/4706791586310449266) started by @Night-Hawkeye*