### PR TITLE
🔒 Fix Information Exposure via Stack Trace Logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 
 import sys
-import traceback
 from datetime import datetime
 from http import HTTPStatus
 
@@ -26,7 +25,6 @@ ADAPTER = CloudAdapter(ConfigurationBotFrameworkAuthentication(CONFIG))
 # Catch-all for errors.
 async def on_error(context: TurnContext, error: Exception):
     print(f"\n [on_turn_error] unhandled error: {error}", file=sys.stderr)
-    traceback.print_exc()
 
     # Send a message to the user
     await context.send_activity("The bot encountered an error or bug.")


### PR DESCRIPTION
🎯 **What:** Removed `traceback.print_exc()` from the unhandled error handler in `app.py`.
⚠️ **Risk:** Logging full stack traces to standard error can expose sensitive internal application details, creating an information exposure vulnerability that attackers could leverage to map the system.
🛡️ **Solution:** Removed the `traceback` import and the full stack trace logging. Unhandled errors now only emit a generic log message via `print(..., file=sys.stderr)`, successfully obscuring the internal execution context while still notifying administrators of the error.

---
*PR created automatically by Jules for task [10538037125891674046](https://jules.google.com/task/10538037125891674046) started by @Night-Hawkeye*