### PR TITLE
🧹 Remove unused json_response import

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from http import HTTPStatus
 
 from aiohttp import web
-from aiohttp.web import Request, Response, json_response
+from aiohttp.web import Request, Response
 from botbuilder.core import (
     TurnContext,
 )


### PR DESCRIPTION
🎯 **What:** Removed the unused `json_response` import from the `aiohttp.web` import statement in `app.py`.
💡 **Why:** `json_response` was imported but never used in the script. Removing it cleans up the codebase and improves code health by reducing unnecessary dependencies and potential confusion for other developers.
✅ **Verification:** Ran the full test suite and confirmed that all 38 tests pass, verifying that removing the import did not introduce any regressions or break existing functionality.
✨ **Result:** A cleaner, more maintainable `app.py` file with no unused imports.

---
*PR created automatically by Jules for task [16917759084043813440](https://jules.google.com/task/16917759084043813440) started by @Night-Hawkeye*