### PR TITLE
🔒 Fix hardcoded empty string default for APP_PASSWORD

### DIFF
--- a/config.py
+++ b/config.py
@@ -9,6 +9,6 @@ class DefaultConfig:
 
     PORT = 3978
     APP_ID = os.environ.get("MicrosoftAppId", "")
-    APP_PASSWORD = os.environ.get("MicrosoftAppPassword", "")
+    APP_PASSWORD = os.environ.get("MicrosoftAppPassword")
     APP_TYPE = os.environ.get("MicrosoftAppType", "MultiTenant")
     APP_TENANTID = os.environ.get("MicrosoftAppTenantId", "")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,7 +12,7 @@ class TestConfig(unittest.TestCase):
             importlib.reload(config)
             self.assertEqual(config.DefaultConfig.PORT, 3978)
             self.assertEqual(config.DefaultConfig.APP_ID, "")
-            self.assertEqual(config.DefaultConfig.APP_PASSWORD, "")
+            self.assertIsNone(config.DefaultConfig.APP_PASSWORD)
             self.assertEqual(config.DefaultConfig.APP_TYPE, "MultiTenant")
             self.assertEqual(config.DefaultConfig.APP_TENANTID, "")
 


### PR DESCRIPTION
🎯 **What:** The `APP_PASSWORD` in `config.py` was defaulting to an empty string `""` when the environment variable was missing. It now defaults to `None`.
⚠️ **Risk:** Hardcoding an empty string as a default for passwords or secrets can bypass checks that look for truthy values, potentially leading to misconfigurations or security flags in static analysis.
🛡️ **Solution:** Removed the empty string default fallback `""` from `os.environ.get("MicrosoftAppPassword")` so it naturally defaults to `None`. Updated `tests/test_config.py` to assert for `None` instead of `""`.

---
*PR created automatically by Jules for task [6332372050158828846](https://jules.google.com/task/6332372050158828846) started by @Night-Hawkeye*