### PR TITLE
🔒 Fix predictable random seed in benchmark.py

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -4,18 +4,22 @@ import pandas as pd
 import secrets
 from datetime import datetime, timedelta
 
-def original(days=10000, initial_price=50000.0, volatility=0.04, drift=0.001):
-    np.random.seed(42)
+def original(days=10000, initial_price=50000.0, volatility=0.04, drift=0.001, seed=None):
+    if seed is None:
+        seed = secrets.randbits(128)
+    rng = np.random.default_rng(seed)
     prices = [initial_price]
     for _ in range(1, days):
-        shock = np.random.normal(0, 1)
+        shock = rng.normal(0, 1)
         price_change = np.exp((drift - 0.5 * volatility**2) + volatility * shock)
         prices.append(prices[-1] * price_change)
     return prices
 
-def optimized(days=10000, initial_price=50000.0, volatility=0.04, drift=0.001):
-    np.random.seed(42)
-    shocks = np.random.normal(0, 1, days - 1)
+def optimized(days=10000, initial_price=50000.0, volatility=0.04, drift=0.001, seed=None):
+    if seed is None:
+        seed = secrets.randbits(128)
+    rng = np.random.default_rng(seed)
+    shocks = rng.normal(0, 1, days - 1)
     price_changes = np.exp((drift - 0.5 * volatility**2) + volatility * shocks)
     prices = np.concatenate(([initial_price], initial_price * np.cumprod(price_changes)))
     return prices.tolist()
@@ -28,6 +32,7 @@ if __name__ == '__main__':
     print(f"Speedup: {t_orig/t_opt:.2f}x")
 
     # Assert correctness
-    orig_res = original(days=10)
-    opt_res = optimized(days=10)
+    test_seed = secrets.randbits(128)
+    orig_res = original(days=10, seed=test_seed)
+    opt_res = optimized(days=10, seed=test_seed)
     assert np.allclose(orig_res, opt_res), f"Results do not match!\nOrig: {orig_res}\nOpt: {opt_res}"


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Replaced the hardcoded predictable random seed (`np.random.seed(42)`) in the `benchmark.py` script with cryptographically secure seeding. Now, if no seed is explicitly provided, it generates a secure 128-bit seed using `secrets.randbits(128)` and uses it to instantiate the modern NumPy Generator (`np.random.default_rng()`).

⚠️ **Risk:** The potential impact if left unfixed
Hardcoded seeds make the random number generation—and thus the output of the benchmark script—entirely predictable. This creates a security risk where an attacker could anticipate the generated shock values and resulting simulated data.

🛡️ **Solution:** How the fix addresses the vulnerability
Removed `np.random.seed(42)` and the global state mutation. Introduced a secure default seed via `secrets.randbits(128)` fed into `np.random.default_rng(seed)`. Used the `rng.normal()` method to securely and unpredictably generate shocks. Maintained functionality by allowing an optional seed to be passed in, and updated the `__main__` block to pass a newly generated test seed for correctly asserting behavior between the two functions.

---
*PR created automatically by Jules for task [17713623314563697057](https://jules.google.com/task/17713623314563697057) started by @Night-Hawkeye*