### PR TITLE
🔒 Fix Predictable Random Seed in benchmark

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -4,30 +4,36 @@ import pandas as pd
 import secrets
 from datetime import datetime, timedelta
 
-def original(days=10000, initial_price=50000.0, volatility=0.04, drift=0.001):
-    np.random.seed(42)
+def original(days=10000, initial_price=50000.0, volatility=0.04, drift=0.001, seed=None):
+    if seed is None:
+        seed = secrets.randbits(128)
+    rng = np.random.default_rng(seed)
     prices = [initial_price]
     for _ in range(1, days):
-        shock = np.random.normal(0, 1)
+        shock = rng.normal(0, 1)
         price_change = np.exp((drift - 0.5 * volatility**2) + volatility * shock)
         prices.append(prices[-1] * price_change)
     return prices
 
-def optimized(days=10000, initial_price=50000.0, volatility=0.04, drift=0.001):
-    np.random.seed(42)
-    shocks = np.random.normal(0, 1, days - 1)
+def optimized(days=10000, initial_price=50000.0, volatility=0.04, drift=0.001, seed=None):
+    if seed is None:
+        seed = secrets.randbits(128)
+    rng = np.random.default_rng(seed)
+    shocks = rng.normal(0, 1, days - 1)
     price_changes = np.exp((drift - 0.5 * volatility**2) + volatility * shocks)
     prices = np.concatenate(([initial_price], initial_price * np.cumprod(price_changes)))
     return prices.tolist()
 
 if __name__ == '__main__':
-    t_orig = timeit.timeit('original()', globals=globals(), number=100)
-    t_opt = timeit.timeit('optimized()', globals=globals(), number=100)
+    bench_seed = secrets.randbits(128)
+    t_orig = timeit.timeit(f'original(seed={bench_seed})', globals=globals(), number=100)
+    t_opt = timeit.timeit(f'optimized(seed={bench_seed})', globals=globals(), number=100)
     print(f"Original: {t_orig:.4f}s")
     print(f"Optimized: {t_opt:.4f}s")
     print(f"Speedup: {t_orig/t_opt:.2f}x")
 
     # Assert correctness
-    orig_res = original(days=10)
-    opt_res = optimized(days=10)
+    test_seed = secrets.randbits(128)
+    orig_res = original(days=10, seed=test_seed)
+    opt_res = optimized(days=10, seed=test_seed)
     assert np.allclose(orig_res, opt_res), f"Results do not match!\nOrig: {orig_res}\nOpt: {opt_res}"


### PR DESCRIPTION
🎯 **What:** Replaced the hardcoded, deterministic `np.random.seed(42)` in `benchmark.py` with the secure `np.random.default_rng(seed)` generator using cryptographic values from `secrets.randbits(128)` as fallback seeds. Updated function signatures to allow deterministic seeding during tests.

⚠️ **Risk:** Hardcoded seeds in random number generation result in entirely predictable outputs. In financial, benchmarking, or randomized simulation scripts, this can invalidate results or allow attackers to predict outcomes to game the system if this code is ever utilized in a production setting.

🛡️ **Solution:** Removed `np.random.seed(42)` and instantiated a modern `np.random.default_rng(seed)`. If the optional `seed` parameter is omitted, a secure 128-bit seed generated by the `secrets` module is passed. `timeit` tests and sequence match tests were appropriately updated with random shared seeds to enforce test accuracy without compromising security.

---
*PR created automatically by Jules for task [12340749559899940618](https://jules.google.com/task/12340749559899940618) started by @Night-Hawkeye*