### PR TITLE
🧹 Refactor numpy random state sharing to use Generator API

### DIFF
--- a/bitcoin_script.py
+++ b/bitcoin_script.py
@@ -6,11 +6,11 @@ from datetime import datetime, timedelta, timezone
 def simulate_bitcoin_prices(days=60, initial_price=50000.0, volatility=0.04, drift=0.001):
     """Simulate Bitcoin prices using Geometric Brownian Motion."""
     # Use secrets for secure randomness
-    np.random.seed(secrets.randbits(32))
+    rng = np.random.default_rng(secrets.randbits(32))
 
     days_to_simulate = max(0, days - 1)
     if days_to_simulate > 0:
-        shocks = np.random.normal(0, 1, days_to_simulate)
+        shocks = rng.normal(0, 1, days_to_simulate)
         price_changes = np.exp((drift - 0.5 * volatility**2) + volatility * shocks)
         prices = np.concatenate(([initial_price], initial_price * np.cumprod(price_changes))).tolist()
     else:

--- a/btc_trader_script.py
+++ b/btc_trader_script.py
@@ -6,10 +6,10 @@ from datetime import datetime, timedelta, timezone
 def simulate_bitcoin_prices(days=60, initial_price=50000, volatility=0.04, drift=0.001):
     """Simulate Bitcoin prices using Geometric Brownian Motion."""
     # Use securely generated seed to avoid predictable simulation
-    np.random.seed(secrets.randbits(32))
+    rng = np.random.default_rng(secrets.randbits(32))
     prices = [initial_price]
     for _ in range(1, days):
-        shock = np.random.normal(0, 1)
+        shock = rng.normal(0, 1)
         price_change = np.exp((drift - 0.5 * volatility**2) + volatility * shock)
         prices.append(prices[-1] * price_change)
 

--- a/simulate_bitcoin_trading.py
+++ b/simulate_bitcoin_trading.py
@@ -6,11 +6,11 @@ from datetime import datetime, timedelta, timezone
 def simulate_bitcoin_prices(days=60, initial_price=50000.0, volatility=0.04, drift=0.001):
     """Simulate Bitcoin prices using Geometric Brownian Motion."""
     # Use secrets for secure randomness
-    np.random.seed(secrets.randbits(32))
+    rng = np.random.default_rng(secrets.randbits(32))
 
     prices = [initial_price]
     for _ in range(1, days):
-        shock = np.random.normal(0, 1)
+        shock = rng.normal(0, 1)
         price_change = np.exp((drift - 0.5 * volatility**2) + volatility * shock)
         prices.append(prices[-1] * price_change)
 


### PR DESCRIPTION
🎯 **What:** Replaced the legacy `np.random.seed(secrets.randbits(32))` and `np.random.normal()` calls with the modern `rng = np.random.default_rng(secrets.randbits(32))` and `rng.normal()` in `btc_trader_script.py`, `bitcoin_script.py`, and `simulate_bitcoin_trading.py`.

💡 **Why:** Using `np.random.seed` modifies the global NumPy random state, which can cause unpredictable behavior across different modules and tests that rely on randomness. Creating and using an isolated `Generator` instance via `default_rng()` is the recommended best practice in NumPy to avoid shared state issues, improving maintainability and isolation.

✅ **Verification:** Verified the code changes using `cat` and successfully ran the full test suite (`pytest tests/ test_*.py`) locally. All 38 tests passed successfully, confirming that functionality remained unaffected.

✨ **Result:** The codebase is safer, cleaner, and less prone to tricky random-state sharing bugs, aligning with modern NumPy development standards.

---
*PR created automatically by Jules for task [3217124552035960723](https://jules.google.com/task/3217124552035960723) started by @Night-Hawkeye*