### PR TITLE
🔒 Fix Command Injection in GitHub Actions Workflow

### DIFF
--- a/.github/workflows/test-1-create-a-branch.yml
+++ b/.github/workflows/test-1-create-a-branch.yml
@@ -75,8 +75,9 @@ jobs:
           ACT_PATH=$(find . -name act -type f -executable | head -n 1)
           sed -i 's/needs: \[find_exercise, check_step_work\]/needs: \[check_step_work\]/g' .github/workflows/1-create-a-branch.yml
           sed -i 's/needs: find_exercise//g' .github/workflows/1-create-a-branch.yml
-          TARGET='\${{ '"'{{'"' }} needs.find_exercise.outputs.issue-url \${{ '"'}}'"' }}'
-          sed -i "s|$TARGET|$ISSUE_URL|g" .github/workflows/1-create-a-branch.yml
+          export TARGET='${{ '"'{{'"' }} needs.find_exercise.outputs.issue-url ${{ '"'}}'"' }}'
+          export ISSUE_URL="$ISSUE_URL"
+          python3 -c "import os; f='.github/workflows/1-create-a-branch.yml'; c=open(f).read(); open(f,'w').write(c.replace(os.environ['TARGET'], os.environ['ISSUE_URL']))"
 
           $ACT_PATH -j check_step_work \
             -e event.json \

--- a/test.sh
+++ b/test.sh
@@ -1,2 +1,0 @@
-export ISSUE_URL="foo"
-echo "s|\${{ needs.find_exercise.outputs.issue-url }}|$ISSUE_URL|g"


### PR DESCRIPTION
🎯 **What:** Fixed a command injection vulnerability in `.github/workflows/test-1-create-a-branch.yml` where `$ISSUE_URL` was unsafely injected into a `sed` command string.

⚠️ **Risk:** Since the `$ISSUE_URL` could potentially contain arbitrary string fragments, injecting it directly into the `sed` substitution command could allow an attacker to escape the `|` delimiter and inject arbitrary bash or `sed` commands, leading to arbitrary code execution within the GitHub Actions runner.

🛡️ **Solution:** Replaced the vulnerable `sed` substitution with a robust Python string replacement command. By extracting `$ISSUE_URL` via `os.environ` and performing literal string matching (`replace`), the solution guarantees that no untrusted input is evaluated by a regex engine or shell parser.

---
*PR created automatically by Jules for task [15488014623772360977](https://jules.google.com/task/15488014623772360977) started by @Night-Hawkeye*