### PR TITLE
🔒 Fix Sensitive Information Exposure in Logs

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,7 +24,7 @@ ADAPTER = CloudAdapter(ConfigurationBotFrameworkAuthentication(CONFIG))
 
 # Catch-all for errors.
 async def on_error(context: TurnContext, error: Exception):
-    print(f"\n [on_turn_error] unhandled error: {error}", file=sys.stderr)
+    print("\n [on_turn_error] unhandled error: An unhandled error occurred.", file=sys.stderr)
 
     # Send a message to the user
     await context.send_activity("The bot encountered an error or bug.")


### PR DESCRIPTION
🎯 **What:** The raw exception object `error` was being printed directly to `stderr` in the global `on_error` handler in `app.py`.
⚠️ **Risk:** Information exposure in standard error logs can leak sensitive internal state information, passwords, API tokens, or detailed stack traces, giving attackers valuable insights to craft targeted attacks.
🛡️ **Solution:** Replaced the detailed exception f-string with a generic, sanitized static log message (`"An unhandled error occurred."`), thereby preventing sensitive information from being exposed in standard error logs while maintaining a trace of the error event.

---
*PR created automatically by Jules for task [12991347766772182828](https://jules.google.com/task/12991347766772182828) started by @Night-Hawkeye*