### PR TITLE
🧪 Add tests for reproduce_issue.py

### DIFF
--- a/tests/test_reproduce_issue.py
+++ b/tests/test_reproduce_issue.py
@@ -1,0 +1,22 @@
+import pytest
+from unittest.mock import patch
+import pandas as pd
+from reproduce_issue import test_predictability
+
+def test_reproduce_issue_vulnerable(capsys):
+    """Test when prices are identical (vulnerable)."""
+    df = pd.DataFrame({'Date': pd.date_range(start='2023-01-01', periods=2), 'Price': [100.0, 105.0]})
+    with patch('reproduce_issue.simulate_bitcoin_prices', return_value=df):
+        test_predictability()
+        captured = capsys.readouterr()
+        assert "VULNERABLE: Prices are identical across multiple runs." in captured.out
+
+def test_reproduce_issue_secure(capsys):
+    """Test when prices differ (secure)."""
+    df1 = pd.DataFrame({'Date': pd.date_range(start='2023-01-01', periods=2), 'Price': [100.0, 105.0]})
+    df2 = pd.DataFrame({'Date': pd.date_range(start='2023-01-01', periods=2), 'Price': [100.0, 110.0]})
+
+    with patch('reproduce_issue.simulate_bitcoin_prices', side_effect=[df1, df2]):
+        test_predictability()
+        captured = capsys.readouterr()
+        assert "SECURE: Prices differ across multiple runs." in captured.out


### PR DESCRIPTION
🎯 **What:** The missing test file for `reproduce_issue.py` has been added.
📊 **Coverage:** The test covers both the VULNERABLE scenario (prices are identical) and the SECURE scenario (prices differ) by using `unittest.mock.patch` to simulate different dataframe responses from `simulate_bitcoin_prices`.
✨ **Result:** Test coverage for `reproduce_issue.py` is now complete, validating that it correctly identifies whether the algorithm output is predictable or not.

---
*PR created automatically by Jules for task [8575025176443688811](https://jules.google.com/task/8575025176443688811) started by @Night-Hawkeye*