### PR TITLE
🧪 [Testing Improvement] Add test for run_app exception path in app.py

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -91,3 +91,12 @@ async def test_on_error_emulator_channel():
     assert trace_activity.type == ActivityTypes.trace
     assert trace_activity.label == "TurnError"
     assert trace_activity.value == "An unhandled error occurred."
+
+
+def test_run_app_exception(mocker):
+    """Test that an exception during web.run_app is raised."""
+    import runpy
+    mocker.patch("app.web.run_app", side_effect=Exception("Test Exception"))
+    import pytest
+    with pytest.raises(Exception, match="Test Exception"):
+        runpy.run_module("app", run_name="__main__")


### PR DESCRIPTION
🎯 **What:** Added a missing test case in `tests/test_app.py` to cover the exception path when `web.run_app` fails in `app.py`.
📊 **Coverage:** The exception path in `app.py`'s `if __name__ == "__main__":` block is now tested, verifying that it correctly raises the exception.
✨ **Result:** Test coverage for `app.py` is improved, ensuring regressions on this error path are caught.

---
*PR created automatically by Jules for task [8615881753588450832](https://jules.google.com/task/8615881753588450832) started by @Night-Hawkeye*