### PR TITLE
🧪 Missing edge case tests for 'days' parameter in benchmark.py

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -3,6 +3,8 @@ import timeit
 import numpy as np
 
 def original(days=10000, initial_price=50000.0, volatility=0.04, drift=0.001, seed=None):
+    if days <= 0:
+        return []
     if seed is None:
         seed = secrets.randbits(128)
     rng = np.random.default_rng(seed)
@@ -14,6 +16,8 @@ def original(days=10000, initial_price=50000.0, volatility=0.04, drift=0.001, se
     return prices
 
 def optimized(days=10000, initial_price=50000.0, volatility=0.04, drift=0.001, seed=None):
+    if days <= 0:
+        return []
     if seed is None:
         seed = secrets.randbits(128)
     rng = np.random.default_rng(seed)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -70,3 +70,10 @@ def test_original_vs_optimized():
     opt_res = optimized(days=10, initial_price=50000.0, volatility=0.04, drift=0.001, seed=test_seed)
 
     assert np.allclose(orig_res, opt_res)
+
+def test_edge_cases():
+    """Test that days <= 0 returns an empty list for both implementations."""
+    assert original(days=0) == []
+    assert optimized(days=0) == []
+    assert original(days=-1) == []
+    assert optimized(days=-1) == []


### PR DESCRIPTION
🎯 **What:** Handled edge cases where `days <= 0` in `benchmark.py` to prevent numpy errors in the optimized version, and added tests for these scenarios.
📊 **Coverage:** Added coverage for `days=0` and `days=-1` to ensure they return empty lists and do not throw exceptions.
✨ **Result:** Increased testing robustness and avoided edge-case regressions when executing benchmark scenarios with zero or negative days.

---
*PR created automatically by Jules for task [343344509411648466](https://jules.google.com/task/343344509411648466) started by @Night-Hawkeye*