### PR TITLE
🔒 Fix Predictable PRNG Seed in simulate_bitcoin_prices

### DIFF
--- a/bitcoin_simulation.py
+++ b/bitcoin_simulation.py
@@ -1,0 +1,13 @@
+import numpy as np
+import pandas as pd
+import secrets
+
+def simulate_bitcoin_prices(days=60, initial_price=50000, volatility=0.04, drift=0.001):
+    """Simulate Bitcoin prices using Geometric Brownian Motion."""
+    # Use dynamically generated secure seed
+    rng = np.random.default_rng(secrets.randbits(128))
+
+    shocks = rng.normal(0, 1, days - 1)
+    price_changes = np.exp((drift - 0.5 * volatility**2) + volatility * shocks)
+    prices = initial_price * np.cumprod(np.insert(price_changes, 0, 1.0))
+    return pd.DataFrame({'Price': prices})


### PR DESCRIPTION
🎯 **What:** Replaced hardcoded deterministic PRNG seed `np.random.default_rng(123)` with a secure, dynamically generated seed using `secrets.randbits(128)`.
⚠️ **Risk:** A predictable pseudo-random number generator seed (CWE-338) allows attackers to predict simulated price paths, which could compromise trading strategy evaluation or exploit deterministic patterns if the simulation is exposed or relied upon for financial decisions.
🛡️ **Solution:** Used `secrets.randbits(128)` to generate a cryptographically secure seed dynamically, preventing predictability while satisfying the prompt constraints.

---
*PR created automatically by Jules for task [7823990513508129947](https://jules.google.com/task/7823990513508129947) started by @Night-Hawkeye*