### PR TITLE
🔒 Fix predictable RNG in trading simulation

### DIFF
--- a/bitcoin_script.py
+++ b/bitcoin_script.py
@@ -4,9 +4,8 @@ from datetime import datetime, timedelta, timezone
 
 def simulate_bitcoin_prices(days=60, initial_price=50000.0, volatility=0.04, drift=0.001):
     """Simulate Bitcoin prices using Geometric Brownian Motion."""
-    import secrets
-    # Use secrets for secure randomness
-    rng = np.random.default_rng(secrets.randbits(32))
+    # Use default_rng without arguments for secure randomness from the OS
+    rng = np.random.default_rng()
 
     shocks = rng.normal(0, 1, days - 1)
     price_changes = np.exp((drift - 0.5 * volatility**2) + volatility * shocks)

--- a/trading_utils.py
+++ b/trading_utils.py
@@ -4,9 +4,8 @@ from datetime import datetime, timedelta, timezone
 
 def simulate_bitcoin_prices(days=60, initial_price=50000.0, volatility=0.04, drift=0.001):
     """Simulate Bitcoin prices using Geometric Brownian Motion."""
-    import secrets
-    # Use secrets for secure randomness
-    rng = np.random.default_rng(secrets.randbits(32))
+    # Use default_rng without arguments for secure randomness from the OS
+    rng = np.random.default_rng()
 
     shocks = rng.normal(0, 1, days - 1)
     price_changes = np.exp((drift - 0.5 * volatility**2) + volatility * shocks)


### PR DESCRIPTION
🎯 **What:** The `np.random.default_rng` instantiation was seeded with `secrets.randbits(32)`, providing only 32 bits of entropy. This makes the generated random sequence predictable.

⚠️ **Risk:** An attacker could brute-force the 32-bit seed space (only ~4.2 billion combinations), predicting the outputs of the simulation. This undermines the security and integrity of the trading algorithm.

🛡️ **Solution:** Removed the explicit seeding with `secrets.randbits(32)` and instead called `np.random.default_rng()` without arguments. This natively pulls secure randomness from the OS entropy pool, preventing predictability and adhering to security best practices. Unused `secrets` imports were also removed.

---
*PR created automatically by Jules for task [9275451139286430679](https://jules.google.com/task/9275451139286430679) started by @Night-Hawkeye*