### PR TITLE
🧹 Remove broad exception catch in web app start

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,7 +60,4 @@ APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":
-    try:
-        web.run_app(APP, host="localhost", port=CONFIG.PORT)
-    except Exception as error:
-        raise error
+    web.run_app(APP, host="localhost", port=CONFIG.PORT)


### PR DESCRIPTION
🎯 **What:** Removed the `try...except` block in `app.py` that caught a generic `Exception` and immediately re-raised it.

💡 **Why:** Catching a generic exception just to immediately re-raise it without adding any additional handling or logging is an anti-pattern. Letting the exception raise naturally simplifies the code, improves readability, and maintains the exact same behavior.

✅ **Verification:** Verified the code changes by running the full test suite (`pytest`) to ensure no functionality was broken. 

✨ **Result:** A cleaner and more maintainable `app.py` initialization block without redundant error handling.

---
*PR created automatically by Jules for task [2021628759811430508](https://jules.google.com/task/2021628759811430508) started by @Night-Hawkeye*