### PR TITLE
🧹 Fix unused import warning in bots module

### DIFF
--- a/bots/__init__.py
+++ b/bots/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from .positive_vibes_bot import PositiveVibesBot
+from .positive_vibes_bot import PositiveVibesBot  # noqa: F401
 
 __all__ = ["PositiveVibesBot"]


### PR DESCRIPTION
🎯 **What:** Suppressed the false-positive unused import warning for `PositiveVibesBot` in `bots/__init__.py`.
💡 **Why:** `PositiveVibesBot` is explicitly exposed via `__all__` for consumers, so removing it breaks the public API. Adding `# noqa: F401` silences the linter warning while preserving the functional behavior of the re-export, improving code health without changing behavior.
✅ **Verification:** Verified that `flake8 bots/__init__.py` reports no warnings and the full test suite passes.
✨ **Result:** A cleaner codebase with no false-positive linter warnings on the module export.

---
*PR created automatically by Jules for task [4966936552255702650](https://jules.google.com/task/4966936552255702650) started by @Night-Hawkeye*