### PR TITLE
🧹 Remove unnecessary try-except block in app startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,7 +60,4 @@ APP = web.Application(middlewares=[aiohttp_error_middleware])
 APP.router.add_post("/api/messages", messages)
 
 if __name__ == "__main__":
-    try:
-        web.run_app(APP, host="localhost", port=CONFIG.PORT)
-    except Exception as error:
-        raise error
+    web.run_app(APP, host="localhost", port=CONFIG.PORT)


### PR DESCRIPTION
🎯 **What:** Removed the broad try-except block that simply re-raised the caught exception without doing anything during `web.run_app` execution.
💡 **Why:** Catching a generic exception just to immediately re-raise it is an anti-pattern. Removing this makes the code simpler and more readable while leaving the error propagation unchanged.
✅ **Verification:** Verified by running the entire test suite via `pytest`, confirming that functionality and failure modes are unchanged.
✨ **Result:** Improved code health and readability without changing behavior.

---
*PR created automatically by Jules for task [17449618155141008640](https://jules.google.com/task/17449618155141008640) started by @Night-Hawkeye*