### PR TITLE
🧹 Fix Duplicate Functions in Benchmark

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -20,8 +20,10 @@ def optimized(days=10000, initial_price=50000.0, volatility=0.04, drift=0.001, s
         seed = secrets.randbits(128)
     rng = np.random.default_rng(seed)
     shocks = rng.normal(0, 1, days - 1)
-    price_changes = np.exp((drift - 0.5 * volatility**2) + volatility * shocks)
-    prices = np.concatenate(([initial_price], initial_price * np.cumprod(price_changes)))
+    log_returns = (drift - 0.5 * volatility**2) + volatility * shocks
+    prices = np.empty(days)
+    prices[0] = initial_price
+    prices[1:] = initial_price * np.exp(np.cumsum(log_returns))
     return prices.tolist()
 
 if __name__ == '__main__':


### PR DESCRIPTION
🎯 **What:** Optimized the `optimized` function in `benchmark.py` to use `np.cumsum` and `np.exp` directly, rather than `np.exp` and `np.cumprod`, resolving identical logic.
💡 **Why:** Having identical code inside `original` and `optimized` fails the goal of benchmarking differences. This provides an actual optimized implementation, making the benchmark meaningful.
✅ **Verification:** Ran `benchmark.py` to assert results matched `original`. Ran `pytest` suite to ensure no regressions.
✨ **Result:** Removed identical duplicate function logic and implemented true optimized math approach, ensuring benchmarking works.

---
*PR created automatically by Jules for task [12542856128422037821](https://jules.google.com/task/12542856128422037821) started by @Night-Hawkeye*