### PR TITLE
🧪 Add tests for _calculate_btc_returns

### DIFF
--- a/test_bitcoin_trader.py
+++ b/test_bitcoin_trader.py
@@ -94,3 +94,27 @@ def test_generate_signals():
     assert signals2[0] == 0.0 # Initial
     assert signals2[1] == 1.0 # Buy
     assert signals2[2] == 0.0 # Sell signal
+
+def test_calculate_btc_returns():
+    import numpy as np
+    from bitcoin_trading import _calculate_btc_returns
+
+    # Test empty array
+    empty_result = _calculate_btc_returns(np.array([]))
+    assert len(empty_result) == 0
+
+    # Test normal prices
+    prices = np.array([100.0, 110.0, 104.5])
+    returns = _calculate_btc_returns(prices)
+    assert len(returns) == 3
+    assert returns[0] == 0.0
+    np.testing.assert_almost_equal(returns[1], 0.1)
+    np.testing.assert_almost_equal(returns[2], -0.05)
+
+    # Test prices with zeros
+    prices_with_zeros = np.array([100.0, 0.0, 50.0])
+    returns_with_zeros = _calculate_btc_returns(prices_with_zeros)
+    assert len(returns_with_zeros) == 3
+    assert returns_with_zeros[0] == 0.0
+    assert returns_with_zeros[1] == -1.0
+    assert returns_with_zeros[2] == 0.0


### PR DESCRIPTION
🎯 **What:** Added tests for the previously untested `_calculate_btc_returns` function in `bitcoin_trading.py`.
📊 **Coverage:** The new tests cover scenarios with an empty array, normal price sequences, and price sequences containing zeros (edge cases to verify correct handling of division by zero).
✨ **Result:** Improved test coverage and reliability for core financial calculation logic.

---
*PR created automatically by Jules for task [7255825004553558784](https://jules.google.com/task/7255825004553558784) started by @Night-Hawkeye*