### PR TITLE
🧹 Refactor: Extract shared RNG setup into a helper function in benchmark.py

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -2,13 +2,16 @@ import secrets
 import timeit
 import numpy as np
 
-def original(days=10000, initial_price=50000.0, volatility=0.04, drift=0.001, seed=None):
-    if days <= 0:
-        return []
+def get_shocks(days, seed):
     if seed is None:
         seed = secrets.randbits(128)
     rng = np.random.default_rng(seed)
-    shocks = rng.normal(0, 1, days - 1)
+    return rng.normal(0, 1, days - 1)
+
+def original(days=10000, initial_price=50000.0, volatility=0.04, drift=0.001, seed=None):
+    if days <= 0:
+        return []
+    shocks = get_shocks(days, seed)
     price_changes = np.exp((drift - 0.5 * volatility**2) + volatility * shocks)
     prices = np.concatenate(([initial_price], initial_price * np.cumprod(price_changes)))
     return prices.tolist()
@@ -16,10 +19,7 @@ def original(days=10000, initial_price=50000.0, volatility=0.04, drift=0.001, se
 def optimized(days=10000, initial_price=50000.0, volatility=0.04, drift=0.001, seed=None):
     if days <= 0:
         return []
-    if seed is None:
-        seed = secrets.randbits(128)
-    rng = np.random.default_rng(seed)
-    shocks = rng.normal(0, 1, days - 1)
+    shocks = get_shocks(days, seed)
     log_returns = (drift - 0.5 * volatility**2) + volatility * shocks
     prices = np.empty(days)
     prices[0] = initial_price


### PR DESCRIPTION
🎯 **What:** Extracted the duplicated random number generator (RNG) setup logic from both the `original` and `optimized` benchmark functions into a new helper function `get_shocks(days, seed)`.
💡 **Why:** Both `original` and `optimized` functions had identical logic for handling the `seed`, initializing the RNG, and generating standard normal shocks. Extracting this common logic into a separate `get_shocks` function eliminates code duplication, making the code cleaner, shorter, and easier to maintain.
✅ **Verification:** Ran `python benchmark.py` to verify that the benchmark functions execute correctly and return the expected identical results (the built-in assert statement inside the file `benchmark.py` testing for equality of arrays successfully passed). Also ran the full test suite (`pytest`) across all tests directory and files to ensure no regressions were introduced.
✨ **Result:** Improved maintainability by centralizing RNG initialization, reducing redundancy, and slightly improving code readability without altering the functionality or logic.

---
*PR created automatically by Jules for task [3327901649617658879](https://jules.google.com/task/3327901649617658879) started by @Night-Hawkeye*