### PR TITLE
🧹 Remove excessive parameters from _generate_actions

### DIFF
--- a/bitcoin_trading.py
+++ b/bitcoin_trading.py
@@ -88,27 +88,20 @@ def _calculate_portfolio(prices, position, initial_cash):
 
     return portfolio_value, cash_held, btc_held
 
-def _generate_actions(prices, position, portfolio_value, btc_held, initial_cash):
-    if len(prices) == 0:
+def _generate_actions(position, portfolio_value, btc_held):
+    if len(position) == 0:
         return np.array([])
     prev_position = np.roll(position, 1)
     prev_position[0] = 0
 
-    prev_portfolio_value = np.roll(portfolio_value, 1)
-    prev_portfolio_value[0] = initial_cash
-
-    prev_prices_arr = np.roll(prices, 1)
-    prev_prices_arr[0] = 1.0
-    safe_prev_prices = np.where(prev_prices_arr != 0, prev_prices_arr, 1.0)
-
-    # The BTC we held yesterday is prev_portfolio_value / prev_prices_arr
-    prev_btc_held = np.where(prev_position == 1, prev_portfolio_value / safe_prev_prices, 0.0)
+    prev_btc_held = np.roll(btc_held, 1)
+    prev_btc_held[0] = 0.0
 
     is_buy = (position == 1) & (prev_position == 0) & (portfolio_value > 0)
     # We sell if we were holding BTC and now we are not. And we only sell if we actually held BTC.
     is_sell = (position == 0) & (prev_position == 1) & (prev_btc_held > 0)
 
-    action = np.full(len(prices), "HOLD", dtype=object)
+    action = np.full(len(position), "HOLD", dtype=object)
 
     buy_indices = np.where(is_buy)[0]
     sell_indices = np.where(is_sell)[0]
@@ -135,7 +128,7 @@ def run_trading_algorithm(df):
 
     position = _generate_signals(ma7, ma30, df.index)
     portfolio_value, cash_held, btc_held = _calculate_portfolio(prices, position, initial_cash)
-    action = _generate_actions(prices, position, portfolio_value, btc_held, initial_cash)
+    action = _generate_actions(position, portfolio_value, btc_held)
 
     return pd.DataFrame({
         'Date': dates,

--- a/tests/test_bitcoin_actions.py
+++ b/tests/test_bitcoin_actions.py
@@ -2,7 +2,7 @@ import numpy as np
 from bitcoin_trading import _generate_actions
 
 def test_generate_actions_empty():
-    actions = _generate_actions(np.array([]), np.array([]), np.array([]), np.array([]), 10000.0)
+    actions = _generate_actions(np.array([]), np.array([]), np.array([]))
     assert len(actions) == 0
 
 def test_generate_actions_hold():
@@ -12,7 +12,7 @@ def test_generate_actions_hold():
     btc_held = np.array([0.0, 0.0, 0.0])
     initial_cash = 10000.0
 
-    actions = _generate_actions(prices, position, portfolio_value, btc_held, initial_cash)
+    actions = _generate_actions(position, portfolio_value, btc_held)
     assert np.array_equal(actions, np.full(3, "HOLD"))
 
 def test_generate_actions_buy():
@@ -22,7 +22,7 @@ def test_generate_actions_buy():
     btc_held = np.array([0.0, 0.2, 0.2])
     initial_cash = 10000.0
 
-    actions = _generate_actions(prices, position, portfolio_value, btc_held, initial_cash)
+    actions = _generate_actions(position, portfolio_value, btc_held)
     assert actions[0] == "HOLD"
     assert actions[1] == "BUY 0.2000 BTC"
     assert actions[2] == "HOLD"
@@ -34,7 +34,7 @@ def test_generate_actions_sell():
     btc_held = np.array([0.0, 0.2, 0.0])
     initial_cash = 10000.0
 
-    actions = _generate_actions(prices, position, portfolio_value, btc_held, initial_cash)
+    actions = _generate_actions(position, portfolio_value, btc_held)
     assert actions[0] == "HOLD"
     assert actions[1] == "BUY 0.2000 BTC"
     assert actions[2] == "SELL 0.2000 BTC"
@@ -46,7 +46,7 @@ def test_generate_actions_sell_initial():
     btc_held = np.array([0.2, 0.2, 0.0])
     initial_cash = 10000.0
 
-    actions = _generate_actions(prices, position, portfolio_value, btc_held, initial_cash)
+    actions = _generate_actions(position, portfolio_value, btc_held)
     assert actions[0] == "BUY 0.2000 BTC"
     assert actions[1] == "HOLD"
     assert actions[2] == "SELL 0.2000 BTC"
@@ -58,7 +58,7 @@ def test_generate_actions_zero_prices():
     btc_held = np.array([0.0, 10000.0, 0.0])
     initial_cash = 10000.0
 
-    actions = _generate_actions(prices, position, portfolio_value, btc_held, initial_cash)
+    actions = _generate_actions(position, portfolio_value, btc_held)
     assert actions[0] == "HOLD"
     assert actions[1] == "BUY 10000.0000 BTC"
     assert actions[2] == "SELL 10000.0000 BTC"

--- a/tests/test_bitcoin_simulation_actions.py
+++ b/tests/test_bitcoin_simulation_actions.py
@@ -7,7 +7,7 @@ def test_generate_actions_empty():
     position = np.array([])
     portfolio_value = np.array([])
     btc_held = np.array([])
-    actions = _generate_actions(prices, position, portfolio_value, btc_held, 10000.0)
+    actions = _generate_actions(position, portfolio_value, btc_held)
     assert len(actions) == 0
 
 def test_generate_actions_hold():
@@ -15,7 +15,7 @@ def test_generate_actions_hold():
     position = np.array([0, 0, 0])
     portfolio_value = np.array([10000.0, 10000.0, 10000.0])
     btc_held = np.array([0.0, 0.0, 0.0])
-    actions = _generate_actions(prices, position, portfolio_value, btc_held, 10000.0)
+    actions = _generate_actions(position, portfolio_value, btc_held)
     assert list(actions) == ["HOLD", "HOLD", "HOLD"]
 
 def test_generate_actions_buy():
@@ -23,7 +23,7 @@ def test_generate_actions_buy():
     position = np.array([0, 1, 1])
     portfolio_value = np.array([10000.0, 10000.0, 10000.0])
     btc_held = np.array([0.0, 95.238, 95.238])
-    actions = _generate_actions(prices, position, portfolio_value, btc_held, 10000.0)
+    actions = _generate_actions(position, portfolio_value, btc_held)
     assert actions[0] == "HOLD"
     assert "BUY" in actions[1]
     assert actions[2] == "HOLD"
@@ -33,7 +33,7 @@ def test_generate_actions_sell():
     position = np.array([0, 1, 0])
     portfolio_value = np.array([10000.0, 10000.0, 20000.0])
     btc_held = np.array([0.0, 50.0, 0.0])
-    actions = _generate_actions(prices, position, portfolio_value, btc_held, 10000.0)
+    actions = _generate_actions(position, portfolio_value, btc_held)
     assert actions[0] == "HOLD"
     assert "BUY" in actions[1]
     assert "SELL" in actions[2]


### PR DESCRIPTION
🎯 **What:** Removed redundant `prices` and `initial_cash` parameters from `_generate_actions` in `bitcoin_trading.py`. Replaced the manual recalculation of previous BTC holdings with a simple array roll of the pre-calculated `btc_held` array.
💡 **Why:** This simplifies the function signature from 5 to 3 parameters, removing internal duplication of logic already handled by `_calculate_portfolio` and reducing complexity. This resolves the code health issue regarding too many parameters.
✅ **Verification:** The full test suite was run (`pytest`) and all existing logic matches the original output, confirmed via an automated script testing 100 random iterations.
✨ **Result:** A much cleaner, simpler `_generate_actions` function that is easier to maintain and read.

---
*PR created automatically by Jules for task [18247431430456045951](https://jules.google.com/task/18247431430456045951) started by @Night-Hawkeye*