### PR TITLE
Fix test_generate_actions_empty arguments

### DIFF
--- a/test_bitcoin_trader.py
+++ b/test_bitcoin_trader.py
@@ -105,6 +105,6 @@ def test_generate_actions_empty():
     btc_held = np.array([])
     initial_cash = 10000.0
 
-    result = _generate_actions(prices, position, portfolio_value, btc_held, initial_cash)
+    result = _generate_actions(position, portfolio_value, btc_held)
     assert len(result) == 0
     assert isinstance(result, np.ndarray)


### PR DESCRIPTION
Fixes TypeError in _generate_actions() by passing correct number of arguments.

---
*PR created automatically by Jules for task [12184599732256476100](https://jules.google.com/task/12184599732256476100) started by @Night-Hawkeye*