### PR TITLE
🧹 Remove unused datetime import from tests/test_trading_utils.py

### DIFF
--- a/tests/test_trading_utils.py
+++ b/tests/test_trading_utils.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import numpy as np
 import pytest
-from datetime import datetime, timedelta
 from bitcoin_trading import run_trading_algorithm, simulate_bitcoin_prices, calculate_moving_averages, SimulationConfig
 
 def create_mock_df(prices, ma7s, ma30s):


### PR DESCRIPTION
🎯 **What:** Removed the unused `datetime` import from `tests/test_trading_utils.py`.
💡 **Why:** Reduces clutter and improves maintainability by eliminating unused dependencies.
✅ **Verification:** Ran the full test suite (`pytest tests/test_trading_utils.py`) to confirm no functionality was broken.
✨ **Result:** A cleaner test file with no unused imports.

---
*PR created automatically by Jules for task [16153622906229316138](https://jules.google.com/task/16153622906229316138) started by @Night-Hawkeye*