### PR TITLE
🧹 Remove unused pytest import in test_predictability.py

### DIFF
--- a/tests/test_predictability.py
+++ b/tests/test_predictability.py
@@ -1,4 +1,3 @@
-import pytest
 from bitcoin_trading import simulate_bitcoin_prices, SimulationConfig
 
 def test_predictability():


### PR DESCRIPTION
🎯 **What:** Removed unused `pytest` import from `tests/test_predictability.py`.
💡 **Why:** Removes unused imports to reduce clutter, improving maintainability and readability.
✅ **Verification:** Ran `python -m pytest` to confirm that the test suite still passes successfully.
✨ **Result:** Cleaned up unused import, leading to better code health without changing behavior.

---
*PR created automatically by Jules for task [16867286353225144474](https://jules.google.com/task/16867286353225144474) started by @Night-Hawkeye*