### PR TITLE
🧹 Remove unused datetime import in test_trading_utils.py

### DIFF
--- a/tests/test_trading_utils.py
+++ b/tests/test_trading_utils.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import numpy as np
 import pytest
-from datetime import datetime, timedelta
 from bitcoin_trading import run_trading_algorithm, simulate_bitcoin_prices, calculate_moving_averages, SimulationConfig
 
 def create_mock_df(prices, ma7s, ma30s):


### PR DESCRIPTION
🎯 **What:** Removed unused `datetime` and `timedelta` imports from `tests/test_trading_utils.py`.
💡 **Why:** Reduces clutter and improves code health by removing an unnecessary import, making the file cleaner.
✅ **Verification:** Ran the test suite via `python -m pytest tests/` to ensure no functionality is broken.
✨ **Result:** Improved maintainability and cleaner code without any impact on functionality.

---
*PR created automatically by Jules for task [17561782901647830709](https://jules.google.com/task/17561782901647830709) started by @Night-Hawkeye*