### PR TITLE
🧹 Fix unused timedelta import

### DIFF
--- a/tests/test_trading_utils.py
+++ b/tests/test_trading_utils.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np
 import pytest
-from datetime import datetime, timedelta
+from datetime import datetime
 from bitcoin_trading import run_trading_algorithm, simulate_bitcoin_prices, calculate_moving_averages, SimulationConfig
 
 def create_mock_df(prices, ma7s, ma30s):


### PR DESCRIPTION
🎯 **What:** Removed unused `timedelta` import from `tests/test_trading_utils.py`.
💡 **Why:** Reduces clutter and avoids unused import warnings, improving maintainability.
✅ **Verification:** Ran pytest to ensure no functionality was affected.
✨ **Result:** Cleaned up test file with no changes to behavior.

---
*PR created automatically by Jules for task [1996672825464554709](https://jules.google.com/task/1996672825464554709) started by @Night-Hawkeye*