### PR TITLE
🧹 Fix invalid type hint syntax for list in positive_vibes_bot.py

### DIFF
--- a/bots/positive_vibes_bot.py
+++ b/bots/positive_vibes_bot.py
@@ -22,7 +22,7 @@ class PositiveVibesBot(ActivityHandler):
         ]
 
     async def on_members_added_activity(
-        self, members_added: [ChannelAccount], turn_context: TurnContext
+        self, members_added: list[ChannelAccount], turn_context: TurnContext
     ):
         tasks = []
         for member in members_added:


### PR DESCRIPTION
🎯 **What:** Fixed invalid type hint syntax for `members_added` by changing `[ChannelAccount]` to `list[ChannelAccount]`.

💡 **Why:** Using an unparameterized list literal `[...]` as a type hint is invalid syntax in Python. Updating it to `list[...]` improves tooling support, static analysis, and prevents potential runtime issues.

✅ **Verification:** Ran the full pytest test suite to confirm the fix preserves all existing functionality and syntax is correct.

✨ **Result:** Improved maintainability and correctness of type hints in the codebase.

---
*PR created automatically by Jules for task [12354944062944177680](https://jules.google.com/task/12354944062944177680) started by @Night-Hawkeye*