### PR TITLE
🧹 Remove unused initial_cash variable from test

### DIFF
--- a/test_bitcoin_trader.py
+++ b/test_bitcoin_trader.py
@@ -99,11 +99,9 @@ def test_generate_actions_empty():
     import numpy as np
     from bitcoin_trading import _generate_actions
 
-    prices = np.array([])
     position = np.array([])
     portfolio_value = np.array([])
     btc_held = np.array([])
-    initial_cash = 10000.0
 
     result = _generate_actions(position, portfolio_value, btc_held)
     assert len(result) == 0


### PR DESCRIPTION
🎯 **What:** Removed unused `initial_cash` variable in `test_generate_actions_empty`.
💡 **Why:** Dead code clutters tests and can cause confusion.
✅ **Verification:** Ran pytest to ensure no functionality was affected and flake8 to verify code health.
✨ **Result:** A cleaner and more maintainable test suite.

---
*PR created automatically by Jules for task [4174371565267928395](https://jules.google.com/task/4174371565267928395) started by @Night-Hawkeye*