### PR TITLE
🧪 Add test for _calculate_strategy_returns empty position edge case

### DIFF
--- a/test_bitcoin_trader.py
+++ b/test_bitcoin_trader.py
@@ -137,3 +137,13 @@ def test_calculate_strategy_returns():
     position_empty = np.array([])
     strat_returns_empty = _calculate_strategy_returns(btc_returns_empty, position_empty)
     assert len(strat_returns_empty) == 0
+
+def test_calculate_strategy_returns_empty_position():
+    import numpy as np
+    from bitcoin_trading import _calculate_strategy_returns
+
+    btc_returns = np.array([0.1, 0.2, 0.3])
+    position = np.array([])
+    strat_returns = _calculate_strategy_returns(btc_returns, position)
+    assert len(strat_returns) == 0
+    assert isinstance(strat_returns, np.ndarray)


### PR DESCRIPTION
🎯 **What:** Added a missing test for the `_calculate_strategy_returns` function to explicitly cover the edge case when the `position` array is empty.
📊 **Coverage:** The test explicitly verifies that passing an empty `position` array along with a non-empty `btc_returns` array correctly returns an empty numpy array without raising errors.
✨ **Result:** Improved test reliability and deterministic safety by explicitly capturing the empty array return behavior of `_calculate_strategy_returns`.

---
*PR created automatically by Jules for task [8438328275961509122](https://jules.google.com/task/8438328275961509122) started by @Night-Hawkeye*