### PR TITLE
🧪 Add tests for _calculate_btc_returns in bitcoin_trading.py

### DIFF
--- a/test_bitcoin_trader.py
+++ b/test_bitcoin_trader.py
@@ -158,3 +158,39 @@ def test_calculate_strategy_returns_empty_position():
     strat_returns = _calculate_strategy_returns(btc_returns, position)
     assert len(strat_returns) == 0
     assert isinstance(strat_returns, np.ndarray)
+
+def test_calculate_btc_returns():
+    import numpy as np
+    from bitcoin_trading import _calculate_btc_returns
+
+    # Test happy path
+    prices = np.array([100.0, 110.0, 99.0, 99.0])
+    returns = _calculate_btc_returns(prices)
+    assert len(returns) == 4
+    np.testing.assert_array_almost_equal(returns, [0.0, 0.1, -0.1, 0.0])
+
+    # Test all zeros
+    prices_zero = np.zeros(5)
+    returns_zero = _calculate_btc_returns(prices_zero)
+    np.testing.assert_array_almost_equal(returns_zero, np.zeros(5))
+
+    # Test empty array
+    prices_empty = np.array([])
+    returns_empty = _calculate_btc_returns(prices_empty)
+    assert len(returns_empty) == 0
+    assert isinstance(returns_empty, np.ndarray)
+
+def test_calculate_btc_returns_edge_cases():
+    import numpy as np
+    from bitcoin_trading import _calculate_btc_returns
+
+    # Test single element
+    prices_single = np.array([100.0])
+    returns_single = _calculate_btc_returns(prices_single)
+    assert len(returns_single) == 1
+    assert returns_single[0] == 0.0
+
+    # Test zero prices (safe division fallback)
+    prices_zero = np.array([0.0, 10.0, 0.0])
+    returns_zero = _calculate_btc_returns(prices_zero)
+    np.testing.assert_array_almost_equal(returns_zero, [0.0, 0.0, -1.0])


### PR DESCRIPTION
🎯 **What:** Added comprehensive tests for `_calculate_btc_returns` function in `bitcoin_trading.py` to `test_bitcoin_trader.py`.
📊 **Coverage:** Covered basic price sequences, single elements, empty arrays, arrays of zeros, and safe division zero denominator edge cases.
✨ **Result:** Improved test reliability and code confidence by covering previously missing functionality tests for bitcoin return calculation.

---
*PR created automatically by Jules for task [7396696439199113305](https://jules.google.com/task/7396696439199113305) started by @Night-Hawkeye*