### PR TITLE
🧹 Fix unused argument in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ CONFIG = DefaultConfig()
 ADAPTER = CloudAdapter(ConfigurationBotFrameworkAuthentication(CONFIG))
 
 # Catch-all for errors.
-async def on_error(context: TurnContext, error: Exception):
+async def on_error(context: TurnContext, _error: Exception):
     print("\n [on_turn_error] unhandled error: An unhandled error occurred.", file=sys.stderr)
 
     # Send a message to the user


### PR DESCRIPTION
🎯 **What:** Renamed the unused `error` argument in the `on_error` function signature in `app.py` to `_error`.
💡 **Why:** Prepending the argument with an underscore clarifies that it is intentionally unused but required by the interface, improving code maintainability.
✅ **Verification:** Verified the fix by running `flake8 app.py` and the full test suite with `PYTHONPATH=. python -m pytest tests/`.
✨ **Result:** Improved code health by resolving the unused argument issue without affecting functionality.

---
*PR created automatically by Jules for task [5560610955740679248](https://jules.google.com/task/5560610955740679248) started by @Night-Hawkeye*